### PR TITLE
Avoid NullPointerException when user clicks repeatedly on a fast way

### DIFF
--- a/library/src/main/java/com/shehabic/droppy/DroppyMenuPopup.java
+++ b/library/src/main/java/com/shehabic/droppy/DroppyMenuPopup.java
@@ -148,7 +148,7 @@ public class DroppyMenuPopup {
     }
 
     protected void dismissPopup(boolean itemSelected) {
-        if (mContentView != null && modalWindow != null) {
+        if (mContentView != null && modalWindow != null && mContentView.getParent() != null && modalWindow.getParent() != null) {
             ((ViewGroup) mContentView.getParent()).removeView(mContentView);
             ((ViewGroup) modalWindow.getParent()).removeView(modalWindow);
 


### PR DESCRIPTION
I've added null checks to avoid NullPointerExceptions in ViewGroup.remove() method